### PR TITLE
Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,26 +9,29 @@ The package sorts out all the boring details and creates a set of MOM6-friendly 
 
 Check out the the [documentation](https://regional-mom6.readthedocs.io/en/latest/) and browse through the [demos](https://regional-mom6.readthedocs.io/en/latest/demos.html).
 
+## Installation
 
-### Installation
-
-At the moment you can install the package via `pip` from Github. To do so, first we create a custom
-conda environment or activate an environment we already have. Then we first need to install `emspy`:
+At the moment you can install the package via `pip` from
+GitHub. Before this, the binary `esmpy` dependency is required. This
+is easiest to install using Conda. To do so, first create a custom
+Conda environment, or activate an existing environment into which you
+want to install `esmpy` and `regional_mom6`. Then install `emspy`:
 
 ```bash
 conda install -c conda-forge esmpy
 ```
 
-and then you can install `regional_mom6` via pip.
-
-(If your environment don't have pip then `conda install pip` should do the job.)
+Alternatively, it's possible to follow the [Installing ESMPy from
+Source](https://earthsystemmodeling.org/esmpy_doc/release/latest/html/install.html#installing-esmpy-from-source)
+instructions to do this in a Conda-free way. With `esmpy` available, you can then install
+`regional_mom6` via pip. If your environment doesn't yet have pip, then `conda install pip` should do the job.
 
 ```bash
 pip install git+https://github.com/COSIMA/regional-mom6.git
 ```
 
 This will install the latest version of `regional_mom6` plus any required dependencies.
-(`esmpy` won't be installed as a dependency and that's why need to install it separately.)
+`esmpy` won't be installed as a dependency and that's why need to install it separately.
 
 Alternatively, you can also install a particular tag or git commit using, e.g.,
 

--- a/README.md
+++ b/README.md
@@ -8,3 +8,34 @@ Users just need to provide some information about where, when, and how big their
 The package sorts out all the boring details and creates a set of MOM6-friendly input files along with setup directories ready to go!
 
 Check out the the [documentation](https://regional-mom6.readthedocs.io/en/latest/) and browse through the [demos](https://regional-mom6.readthedocs.io/en/latest/demos.html).
+
+
+### Installation
+
+At the moment you can install the package via `pip` from Github. To do so first you can create a custom
+conda environment or activate an environment you already have. Then first install `emspy`
+
+```bash
+conda install -c conda-forge esmpy
+```
+
+and then you can install `regional_mom6` via pip.
+
+```bash
+pip install git+https://github.com/COSIMA/regional-mom6.git
+```
+
+This will install the latest version of `regional_mom6` plus any required dependencies.
+(`esmpy` won't be installed as a dependency and that's why we had to install it separately.)
+
+Alternatively, you can also install a particular tag or git commit using, e.g.,
+
+```bash
+pip install git+https://github.com/COSIMA/regional-mom6.git@v0.X.X
+```
+
+or
+
+```bash
+pip install git+https://github.com/COSIMA/regional-mom6.git@061b0ef80c7cbc04de0566df329c4ea472002f7e
+```

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Check out the the [documentation](https://regional-mom6.readthedocs.io/en/latest
 
 ### Installation
 
-At the moment you can install the package via `pip` from Github. To do so, you can first create a custom
-conda environment or activate an environment you already have. Then we need to install `emspy`
+At the moment you can install the package via `pip` from Github. To do so, first we create a custom
+conda environment or activate an environment we already have. Then we first need to install `emspy`:
 
 ```bash
 conda install -c conda-forge esmpy

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Check out the the [documentation](https://regional-mom6.readthedocs.io/en/latest
 
 ### Installation
 
-At the moment you can install the package via `pip` from Github. To do so first you can create a custom
-conda environment or activate an environment you already have. Then first install `emspy`
+At the moment you can install the package via `pip` from Github. To do so, you can first create a custom
+conda environment or activate an environment you already have. Then we need to install `emspy`
 
 ```bash
 conda install -c conda-forge esmpy
@@ -21,12 +21,14 @@ conda install -c conda-forge esmpy
 
 and then you can install `regional_mom6` via pip.
 
+(If your environment don't have pip then `conda install pip` should do the job.)
+
 ```bash
 pip install git+https://github.com/COSIMA/regional-mom6.git
 ```
 
 This will install the latest version of `regional_mom6` plus any required dependencies.
-(`esmpy` won't be installed as a dependency and that's why we had to install it separately.)
+(`esmpy` won't be installed as a dependency and that's why need to install it separately.)
 
 Alternatively, you can also install a particular tag or git commit using, e.g.,
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ configurations for the Modular Ocean Model 6
    :maxdepth: 1
    :caption: Contents:
 
+   installation
    contributing
    api
    demos

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,25 +1,27 @@
 Installation
 ============
 
-You can install the package via `pip` directly from Github.
-
-To do so, first we create a custom conda environment or activate an environment we already have.
-Then we first need to install `emspy`:
+At the moment you can install the package via `pip` from
+GitHub. Before this, the binary `esmpy` dependency is required. This
+is easiest to install using Conda. To do so, first create a custom
+Conda environment, or activate an existing environment into which you
+want to install `esmpy` and `regional_mom6`. Then install `emspy`:
 
 ```{code-block} bash
 conda install -c conda-forge esmpy
 ```
 
-and then you can install `regional_mom6` via pip.
-
-(If your environment don't have pip then `conda install pip` should do the job.)
+Alternatively, it's possible to follow the [Installing ESMPy from
+Source](https://earthsystemmodeling.org/esmpy_doc/release/latest/html/install.html#installing-esmpy-from-source)
+instructions to do this in a Conda-free way. With `esmpy` available, you can then install
+`regional_mom6` via pip. If your environment doesn't yet have pip, then `conda install pip` should do the job.
 
 ```{code-block} bash
 pip install git+https://github.com/COSIMA/regional-mom6.git
 ```
 
 This will install the latest version of `regional_mom6` plus any required dependencies.
-(`esmpy` won't be installed as a dependency and that's why need to install it separately.)
+`esmpy` won't be installed as a dependency and that's why need to install it separately.
 
 Alternatively, you can also install a particular tag or git commit using, e.g.,
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,34 @@
+Installation
+============
+
+You can install the package via `pip` directly from Github.
+
+To do so, first we create a custom conda environment or activate an environment we already have.
+Then we first need to install `emspy`:
+
+```{code-block} bash
+conda install -c conda-forge esmpy
+```
+
+and then you can install `regional_mom6` via pip.
+
+(If your environment don't have pip then `conda install pip` should do the job.)
+
+```{code-block} bash
+pip install git+https://github.com/COSIMA/regional-mom6.git
+```
+
+This will install the latest version of `regional_mom6` plus any required dependencies.
+(`esmpy` won't be installed as a dependency and that's why need to install it separately.)
+
+Alternatively, you can also install a particular tag or git commit using, e.g.,
+
+```{code-block} bash
+pip install git+https://github.com/COSIMA/regional-mom6.git@v0.X.X
+```
+
+or
+
+```{code-block} bash
+pip install git+https://github.com/COSIMA/regional-mom6.git@061b0ef80c7cbc04de0566df329c4ea472002f7e
+```


### PR DESCRIPTION
An attempt to close #40.

```bash
(base) test_mom6/ $ conda create -p ./env
Collecting package metadata (current_repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /Users/navid/Research/test_mom6/env



Proceed ([y]/n)? y

Preparing transaction: done
Verifying transaction: done
Executing transaction: done
#
# To activate this environment, use
#
#     $ conda activate /Users/navid/Research/test_mom6/env
#
# To deactivate an active environment, use
#
#     $ conda deactivate

(base) navid:test_mom6/ $ conda activate /Users/navid/Research/test_mom6/env                                                            [13:52:51]
(/Users/navid/Research/test_mom6/env) navid:test_mom6/ $ conda install -c conda-forge esmpy                                             [13:52:55]
Collecting package metadata (current_repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /Users/navid/Research/test_mom6/env

  added / updated specs:
    - esmpy


The following NEW packages will be INSTALLED:

  blosc              conda-forge/osx-arm64::blosc-1.21.4-hc338f07_0
  bzip2              conda-forge/osx-arm64::bzip2-1.0.8-h3422bc3_4
  c-ares             conda-forge/osx-arm64::c-ares-1.19.1-hb547adb_0
  ca-certificates    conda-forge/osx-arm64::ca-certificates-2023.5.7-hf0a4a13_0
  curl               conda-forge/osx-arm64::curl-8.1.2-h912dcd9_0
  esmf               conda-forge/osx-arm64::esmf-8.4.2-nompi_ha1e40e6_0
  esmpy              conda-forge/noarch::esmpy-8.4.2-pyhc1e730c_1
  hdf4               conda-forge/osx-arm64::hdf4-4.2.15-h8111dcc_6
  hdf5               conda-forge/osx-arm64::hdf5-1.14.0-nompi_h6b85c65_103
  icu                conda-forge/osx-arm64::icu-72.1-he12128b_0
  krb5               conda-forge/osx-arm64::krb5-1.20.1-h69eda48_0
  libaec             conda-forge/osx-arm64::libaec-1.0.6-hb7217d7_1
  libblas            conda-forge/osx-arm64::libblas-3.9.0-17_osxarm64_openblas
  libcblas           conda-forge/osx-arm64::libcblas-3.9.0-17_osxarm64_openblas
  libcurl            conda-forge/osx-arm64::libcurl-8.1.2-h912dcd9_0
  libcxx             conda-forge/osx-arm64::libcxx-16.0.6-h4653b0c_0
  libedit            conda-forge/osx-arm64::libedit-3.1.20191231-hc8eb9b7_2
  libev              conda-forge/osx-arm64::libev-4.33-h642e427_1
  libexpat           conda-forge/osx-arm64::libexpat-2.5.0-hb7217d7_1
  libffi             conda-forge/osx-arm64::libffi-3.4.2-h3422bc3_5
  libgfortran        conda-forge/osx-arm64::libgfortran-5.0.0-12_2_0_hd922786_31
  libgfortran5       conda-forge/osx-arm64::libgfortran5-12.2.0-h0eea778_31
  libiconv           conda-forge/osx-arm64::libiconv-1.17-he4db4b2_0
  libjpeg-turbo      conda-forge/osx-arm64::libjpeg-turbo-2.1.5.1-h1a8c8d9_0
  liblapack          conda-forge/osx-arm64::liblapack-3.9.0-17_osxarm64_openblas
  libnetcdf          conda-forge/osx-arm64::libnetcdf-4.9.2-nompi_h0a2dbf5_105
  libnghttp2         conda-forge/osx-arm64::libnghttp2-1.52.0-hae82a92_0
  libopenblas        conda-forge/osx-arm64::libopenblas-0.3.23-openmp_hc731615_0
  libsqlite          conda-forge/osx-arm64::libsqlite-3.42.0-hb31c410_0
  libssh2            conda-forge/osx-arm64::libssh2-1.11.0-h7a5bd25_0
  libxml2            conda-forge/osx-arm64::libxml2-2.11.4-he3bdae6_0
  libzip             conda-forge/osx-arm64::libzip-1.9.2-h76ab92c_1
  libzlib            conda-forge/osx-arm64::libzlib-1.2.13-h53f4e23_5
  llvm-openmp        conda-forge/osx-arm64::llvm-openmp-16.0.6-h1c12783_0
  lz4-c              conda-forge/osx-arm64::lz4-c-1.9.4-hb7217d7_0
  ncurses            conda-forge/osx-arm64::ncurses-6.4-h7ea286d_0
  netcdf-fortran     conda-forge/osx-arm64::netcdf-fortran-4.6.1-nompi_h8e202b2_100
  numpy              conda-forge/osx-arm64::numpy-1.25.0-py311hb8f3215_0
  openssl            conda-forge/osx-arm64::openssl-3.1.1-h53f4e23_1
  pip                conda-forge/noarch::pip-23.1.2-pyhd8ed1ab_0
  python             conda-forge/osx-arm64::python-3.11.4-h47c9636_0_cpython
  python_abi         conda-forge/osx-arm64::python_abi-3.11-3_cp311
  readline           conda-forge/osx-arm64::readline-8.2-h92ec313_1
  setuptools         conda-forge/noarch::setuptools-67.7.2-pyhd8ed1ab_0
  snappy             conda-forge/osx-arm64::snappy-1.1.10-h17c5cce_0
  tk                 conda-forge/osx-arm64::tk-8.6.12-he1e0b03_0
  tzdata             conda-forge/noarch::tzdata-2023c-h71feb2d_0
  wheel              conda-forge/noarch::wheel-0.40.0-pyhd8ed1ab_0
  xz                 conda-forge/osx-arm64::xz-5.2.6-h57fd34a_0
  zstd               conda-forge/osx-arm64::zstd-1.5.2-hf913c23_6


Proceed ([y]/n)? y


Downloading and Extracting Packages

Preparing transaction: done
Verifying transaction: done
Executing transaction: done
(/Users/navid/Research/test_mom6/env) navid:test_mom6/ $ python3                                                                        [13:53:18]
Python 3.11.4 | packaged by conda-forge | (main, Jun 10 2023, 18:08:41) [Clang 15.0.7 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import regional_mom6
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'regional_mom6'
>>> exit()
(/Users/navid/Research/test_mom6/env) navid:test_mom6/ $ pip install git+https://github.com/COSIMA/regional-mom6.git                    [13:55:33]
Collecting git+https://github.com/COSIMA/regional-mom6.git
  Cloning https://github.com/COSIMA/regional-mom6.git to /private/tmp/pip-req-build-7qvmmewr
  Running command git clone --filter=blob:none --quiet https://github.com/COSIMA/regional-mom6.git /private/tmp/pip-req-build-7qvmmewr
  Resolved https://github.com/COSIMA/regional-mom6.git to commit 061b0ef80c7cbc04de0566df329c4ea472002f7e
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... done
Collecting dask[array] (from regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached dask-2023.6.0-py3-none-any.whl (1.2 MB)
Requirement already satisfied: numpy>=1.17.0 in ./env/lib/python3.11/site-packages (from regional-mom6==0.2.1.dev73+g061b0ef) (1.25.0)
Collecting scipy>=1.2.0 (from regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached scipy-1.10.1-cp311-cp311-macosx_12_0_arm64.whl (28.7 MB)
Collecting netCDF4 (from regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached netCDF4-1.6.4-cp311-cp311-macosx_11_0_arm64.whl (3.2 MB)
Collecting xarray (from regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached xarray-2023.5.0-py3-none-any.whl (994 kB)
Collecting xesmf (from regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached xesmf-0.7.1-py3-none-any.whl (41 kB)
Collecting click>=8.0 (from dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached click-8.1.3-py3-none-any.whl (96 kB)
Collecting cloudpickle>=1.5.0 (from dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached cloudpickle-2.2.1-py3-none-any.whl (25 kB)
Collecting fsspec>=2021.09.0 (from dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached fsspec-2023.6.0-py3-none-any.whl (163 kB)
Collecting packaging>=20.0 (from dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached packaging-23.1-py3-none-any.whl (48 kB)
Collecting partd>=1.2.0 (from dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached partd-1.4.0-py3-none-any.whl (18 kB)
Collecting pyyaml>=5.3.1 (from dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl (167 kB)
Collecting toolz>=0.10.0 (from dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached toolz-0.12.0-py3-none-any.whl (55 kB)
Collecting importlib-metadata>=4.13.0 (from dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached importlib_metadata-6.7.0-py3-none-any.whl (22 kB)
Collecting distributed==2023.6.0 (from dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached distributed-2023.6.0-py3-none-any.whl (976 kB)
Collecting jinja2>=2.10.3 (from distributed==2023.6.0->dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached Jinja2-3.1.2-py3-none-any.whl (133 kB)
Collecting locket>=1.0.0 (from distributed==2023.6.0->dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached locket-1.0.0-py2.py3-none-any.whl (4.4 kB)
Collecting msgpack>=1.0.0 (from distributed==2023.6.0->dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached msgpack-1.0.5-cp311-cp311-macosx_11_0_arm64.whl (69 kB)
Collecting psutil>=5.7.2 (from distributed==2023.6.0->dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached psutil-5.9.5-cp38-abi3-macosx_11_0_arm64.whl (246 kB)
Collecting sortedcontainers>=2.0.5 (from distributed==2023.6.0->dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached sortedcontainers-2.4.0-py2.py3-none-any.whl (29 kB)
Collecting tblib>=1.6.0 (from distributed==2023.6.0->dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached tblib-2.0.0-py3-none-any.whl (11 kB)
Collecting tornado>=6.0.4 (from distributed==2023.6.0->dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached tornado-6.3.2-cp38-abi3-macosx_10_9_universal2.whl (424 kB)
Collecting urllib3>=1.24.3 (from distributed==2023.6.0->dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached urllib3-2.0.3-py3-none-any.whl (123 kB)
Collecting zict>=2.2.0 (from distributed==2023.6.0->dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached zict-3.0.0-py2.py3-none-any.whl (43 kB)
Collecting cftime (from netCDF4->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached cftime-1.6.2-cp311-cp311-macosx_11_0_arm64.whl (207 kB)
Collecting certifi (from netCDF4->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached certifi-2023.5.7-py3-none-any.whl (156 kB)
Collecting pandas>=1.4 (from xarray->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached pandas-2.0.2-cp311-cp311-macosx_11_0_arm64.whl (10.7 MB)
Collecting cf-xarray>=0.5.1 (from xesmf->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached cf_xarray-0.8.1-py3-none-any.whl (56 kB)
Collecting numba>=0.55.2 (from xesmf->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached numba-0.57.1-cp311-cp311-macosx_11_0_arm64.whl (2.5 MB)
Collecting shapely (from xesmf->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached shapely-2.0.1-cp311-cp311-macosx_11_0_arm64.whl (1.2 MB)
Collecting sparse>=0.8.0 (from xesmf->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached sparse-0.14.0-py2.py3-none-any.whl (80 kB)
Collecting zipp>=0.5 (from importlib-metadata>=4.13.0->dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached zipp-3.15.0-py3-none-any.whl (6.8 kB)
Collecting llvmlite<0.41,>=0.40.0dev0 (from numba>=0.55.2->xesmf->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached llvmlite-0.40.1-cp311-cp311-macosx_11_0_arm64.whl (28.1 MB)
Collecting numpy>=1.17.0 (from regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached numpy-1.24.3-cp311-cp311-macosx_11_0_arm64.whl (13.8 MB)
Collecting python-dateutil>=2.8.2 (from pandas>=1.4->xarray->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
Collecting pytz>=2020.1 (from pandas>=1.4->xarray->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached pytz-2023.3-py2.py3-none-any.whl (502 kB)
Collecting tzdata>=2022.1 (from pandas>=1.4->xarray->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached tzdata-2023.3-py2.py3-none-any.whl (341 kB)
Collecting MarkupSafe>=2.0 (from jinja2>=2.10.3->distributed==2023.6.0->dask[array]->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached MarkupSafe-2.1.3-cp311-cp311-macosx_10_9_universal2.whl (17 kB)
Collecting six>=1.5 (from python-dateutil>=2.8.2->pandas>=1.4->xarray->regional-mom6==0.2.1.dev73+g061b0ef)
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Building wheels for collected packages: regional-mom6
  Building wheel for regional-mom6 (pyproject.toml) ... done
  Created wheel for regional-mom6: filename=regional_mom6-0.2.1.dev73+g061b0ef-py3-none-any.whl size=49200 sha256=b39b4e89cff484361eec05fea0ebb3367d973fa9be63586608fb0cc7a25bae0e
  Stored in directory: /private/tmp/pip-ephem-wheel-cache-3ahcxkib/wheels/e6/1b/04/7826901718b46c1c6efc04bcba964bfbb79eef23787df82486
Successfully built regional-mom6
Installing collected packages: sortedcontainers, pytz, msgpack, zipp, zict, urllib3, tzdata, tornado, toolz, tblib, six, pyyaml, psutil, packaging, numpy, MarkupSafe, locket, llvmlite, fsspec, cloudpickle, click, certifi, shapely, scipy, python-dateutil, partd, numba, jinja2, importlib-metadata, cftime, sparse, pandas, netCDF4, dask, xarray, distributed, cf-xarray, xesmf, regional-mom6
  Attempting uninstall: numpy
    Found existing installation: numpy 1.25.0
    Uninstalling numpy-1.25.0:
      Successfully uninstalled numpy-1.25.0
Successfully installed MarkupSafe-2.1.3 certifi-2023.5.7 cf-xarray-0.8.1 cftime-1.6.2 click-8.1.3 cloudpickle-2.2.1 dask-2023.6.0 distributed-2023.6.0 fsspec-2023.6.0 importlib-metadata-6.7.0 jinja2-3.1.2 llvmlite-0.40.1 locket-1.0.0 msgpack-1.0.5 netCDF4-1.6.4 numba-0.57.1 numpy-1.24.3 packaging-23.1 pandas-2.0.2 partd-1.4.0 psutil-5.9.5 python-dateutil-2.8.2 pytz-2023.3 pyyaml-6.0 regional-mom6-0.2.1.dev73+g061b0ef scipy-1.10.1 shapely-2.0.1 six-1.16.0 sortedcontainers-2.4.0 sparse-0.14.0 tblib-2.0.0 toolz-0.12.0 tornado-6.3.2 tzdata-2023.3 urllib3-2.0.3 xarray-2023.5.0 xesmf-0.7.1 zict-3.0.0 zipp-3.15.0
(/Users/navid/Research/test_mom6/env) navid:test_mom6/ $ python                                                                         [13:55:52]
Python 3.11.4 | packaged by conda-forge | (main, Jun 10 2023, 18:08:41) [Clang 15.0.7 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import regional_mom6
>>>
```