### PR TITLE
Made the use of FRE tools optional, and stopped them being called on …

### DIFF
--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -832,8 +832,7 @@ class experiment:
         fill_channels=False,
         minimum_layers=3,
         maketopog=True,
-        positivedown=False,
-        run_fretools = True
+        positivedown=False
     ):
         """Cuts out and interpolates chosen bathymetry, then fills
         inland lakes.
@@ -857,11 +856,7 @@ class experiment:
                 make topography (if true), or read an existing file.
             positivedown (Optional[bool]): If true, assumes that
                 bathymetry vertical coordinate is positive down.
-            run_fretools (Optional[bool]): If true, runs FREtools to
-                generate mosaic & masks. Set to false for testing purposes
-                if you don't have FRE tools compiled. Otherwise should be 
-                set to true to ensure that the masks are updated with changes
-                to topography. 
+
 
         """
 
@@ -1099,41 +1094,13 @@ class experiment:
             "mv topog_deseas.nc topog.nc", shell=True, cwd=self.mom_input_dir
         )
 
-        if run_fretools == True:
-
-            ## FINAL STEP: run the remaining FRE tools to construct masks based on our topography
-
-            args = "--num_tiles 1 --dir . --mosaic_name ocean_mosaic --tile_file hgrid.nc".split(
-                " "
-            )
-            print(
-                "MAKE SOLO MOSAIC",
-                subprocess.run(
-                    self.toolpath
-                    + "make_solo_mosaic/make_solo_mosaic --num_tiles 1 --dir . --mosaic_name ocean_mosaic --tile_file hgrid.nc",
-                    shell=True,
-                    cwd=self.mom_input_dir,
-                ),
-                sep="\n\n",
-            )
-
-            print(
-                "QUICK MOSAIC",
-                subprocess.run(
-                    self.toolpath
-                    + "make_quick_mosaic/make_quick_mosaic --input_mosaic ocean_mosaic.nc --mosaic_name grid_spec --ocean_topog topog.nc",
-                    shell=True,
-                    cwd=self.mom_input_dir,
-                ),
-                sep="\n\n",
-            )
 
         self.topog = topog
         return
 
-    def processor_mask(self, layout):
+    def FRE_tools(self, layout):
         """
-        Just a wrapper for FRE Tools check_mask. User provides processor layout tuple of processing units.
+        Just a wrapper for FRE Tools check_mask, make_solo_mosaic and make_quick_mosaic. User provides processor layout tuple of processing units.
         """
 
         if "topog.nc" not in os.listdir(self.mom_input_dir):
@@ -1145,6 +1112,29 @@ class experiment:
             )  ## Removes old mask table so as not to clog up inputdir
         except:
             pass
+        
+        print(
+            "MAKE SOLO MOSAIC",
+            subprocess.run(
+                self.toolpath
+                + "make_solo_mosaic/make_solo_mosaic --num_tiles 1 --dir . --mosaic_name ocean_mosaic --tile_file hgrid.nc",
+                shell=True,
+                cwd=self.mom_input_dir,
+            ),
+            sep="\n\n",
+        )
+
+        print(
+            "QUICK MOSAIC",
+            subprocess.run(
+                self.toolpath
+                + "make_quick_mosaic/make_quick_mosaic --input_mosaic ocean_mosaic.nc --mosaic_name grid_spec --ocean_topog topog.nc",
+                shell=True,
+                cwd=self.mom_input_dir,
+            ),
+            sep="\n\n",
+        )
+        
         print(
             "CHECK MASK",
             subprocess.run(

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -832,7 +832,7 @@ class experiment:
         fill_channels=False,
         minimum_layers=3,
         maketopog=True,
-        positivedown=False
+        positivedown=False,
     ):
         """Cuts out and interpolates chosen bathymetry, then fills
         inland lakes.
@@ -1094,7 +1094,6 @@ class experiment:
             "mv topog_deseas.nc topog.nc", shell=True, cwd=self.mom_input_dir
         )
 
-
         self.topog = topog
         return
 
@@ -1112,7 +1111,7 @@ class experiment:
             )  ## Removes old mask table so as not to clog up inputdir
         except:
             pass
-        
+
         print(
             "MAKE SOLO MOSAIC",
             subprocess.run(
@@ -1134,7 +1133,7 @@ class experiment:
             ),
             sep="\n\n",
         )
-        
+
         print(
             "CHECK MASK",
             subprocess.run(


### PR DESCRIPTION
Simple PR. I've just removed the calling of FRE tools (mosaic , check mask , ocean mask) from all other functions and put them in their own stand alone wrapper called FRE_tools. This way we can test all of the Python code before we've incorporated the FRE tools into the pipeline, and also write separate tests for the FRE tool compatibility. 