### PR TITLE
Bugfix: Bathymetry regridding and B grid velocity regridding. 

### DIFF
--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1401,12 +1401,9 @@ class segment:
                     ),
                     regridder_tracer(
                         rawseg[
-                            [self.eta.rename({self.xh: "lon", self.yh: "lat"})]
-                            + [
-                                self.tracers[i].rename({self.xh: "lon", self.yh: "lat"})
-                                for i in self.tracers
-                            ]
-                        ]
+                            [self.eta]
+                            + [self.tracers[i] for i in self.tracers]
+                        ].rename({self.xh: "lon", self.yh: "lat"})
                     ),
                 ]
             )

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1021,9 +1021,7 @@ class experiment:
         topog = xr.open_dataset(self.mom_input_dir / "topog_raw.nc", engine="netcdf4")
 
         ## Ensure correct encoding
-        topog = xr.Dataset(
-            {"depth": (["ny", "nx"], topog["elevation"].values)}
-        )
+        topog = xr.Dataset({"depth": (["ny", "nx"], topog["elevation"].values)})
         topog.attrs["depth"] = "meters"
         topog.attrs["standard_name"] = "topographic depth at T-cell centers"
         topog.attrs["coordinates"] = "zi"

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1401,8 +1401,7 @@ class segment:
                     ),
                     regridder_tracer(
                         rawseg[
-                            [self.eta]
-                            + [self.tracers[i] for i in self.tracers]
+                            [self.eta] + [self.tracers[i] for i in self.tracers]
                         ].rename({self.xh: "lon", self.yh: "lat"})
                     ),
                 ]

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1022,7 +1022,7 @@ class experiment:
 
         ## Ensure correct encoding
         topog = xr.Dataset(
-            {"depth": (["ny", "nx"], topog[varnames["elevation"]].values)}
+            {"depth": (["ny", "nx"], topog["elevation"].values)}
         )
         topog.attrs["depth"] = "meters"
         topog.attrs["standard_name"] = "topographic depth at T-cell centers"


### PR DESCRIPTION
at this step the intermediate 'topog_raw.nc' file already has vertical coordinate named elevation. Threw an error when vcoord had different name