### PR TITLE
Add `xarray` upper bound to avoid v2024.02.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "netCDF4",
   "numpy>=1.17.0",
   "scipy>=1.2.0",
-  "xarray",
+  "xarray<2024.02.0",
   "xesmf>=0.8",
   "f90nml>=1.4.1",
 ]


### PR DESCRIPTION
After the [latest xarray release](https://github.com/pydata/xarray/releases/tag/v2024.02.0) errors started appearing in the CI. See, for example, https://github.com/COSIMA/regional-mom6/actions/runs/7957078139/job/21719091616#step:7:226


See https://github.com/pydata/xarray/issues/8769

Adding an upper bound in `pyproject` to preclude the xarray v2024.02.0 resolves the issue for now until a patch release comes out from xarray.