### PR TITLE
Tolerence of 10^-14 for even spacing too strict

### DIFF
--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -539,7 +539,7 @@ def rectangular_hgrid(λ, φ):
     dλ = λ[1] - λ[0]
 
     assert (
-        np.max(np.diff(λ) - dλ) < 1e-10
+        np.allclose(np.diff(λ), dλ * np.ones(np.size(λ)-1))
     ), "provided array of longitudes must be uniformly spaced"
 
     # dx = R * cos(φ) * np.deg2rad(dλ) / 2

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -206,8 +206,8 @@ def longitude_slicer(data, longitude_extent, longitude_coords, buffer=2):
 
         dλ = data[lon][1] - data[lon][0]
 
-        assert (
-            np.max(np.abs(np.diff(data[lon]) - dλ)) < 1e-14
+        assert np.allclose(
+            np.diff(data[lon]), dλ * np.ones(np.size(λ) - 1)
         ), "provided longitude coordinate must be uniformly spaced"
 
         assert np.isclose(
@@ -538,8 +538,8 @@ def rectangular_hgrid(λ, φ):
     # compute longitude spacing and ensure that longitudes are uniformly spaced
     dλ = λ[1] - λ[0]
 
-    assert (
-        np.allclose(np.diff(λ), dλ * np.ones(np.size(λ)-1))
+    assert np.allclose(
+        np.diff(λ), dλ * np.ones(np.size(λ) - 1)
     ), "provided array of longitudes must be uniformly spaced"
 
     # dx = R * cos(φ) * np.deg2rad(dλ) / 2

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -440,7 +440,7 @@ def rectangular_hgrid(λ, φ):
     dλ = λ[1] - λ[0]
 
     assert (
-        np.max(np.diff(λ) - dλ) < 1e-14
+        np.max(np.diff(λ) - dλ) < 1e-10
     ), "provided array of longitudes must be uniformly spaced"
 
     # dx = R * cos(φ) * np.deg2rad(dλ) / 2


### PR DESCRIPTION
The assertion that the grid spacing must not vary by more than 10^-14 fails for high enough resolution runs. To replicate, set `resolution = 0.0125`, with an `xextent` and `yextent` of 30 degrees or so. What happens is that because the memory is symmetric, we need to have an odd number of longitude points so that it starts and finishes with a q point. I guess that dividing by an odd number results in some numerical error, which for high enough resolution exceeds 10^-14.

I suggest changing this tolerance to 10^-10