### PR TITLE
Fix bug + test assertion error in `longitude_slicer`

### DIFF
--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -204,10 +204,14 @@ def longitude_slicer(data, longitude_extent, longitude_coords, buffer=2):
         ## Find a corresponding value for the intended domain midpoint in our data.
         ## It's assumed that data has equally-spaced longitude values that span 360 degrees.
 
-        dλ = data[lon][1] - data[lon][0]
+        λ = data[lon].data
+        dλ = λ[1] - λ[0]
+
+        print(λ)
+        print(dλ)
 
         assert np.allclose(
-            np.diff(data[lon]), dλ * np.ones(np.size(λ) - 1)
+            np.diff(λ), dλ * np.ones(np.size(λ) - 1)
         ), "provided longitude coordinate must be uniformly spaced"
 
         assert np.isclose(

--- a/tests/test_grid_generation.py
+++ b/tests/test_grid_generation.py
@@ -3,6 +3,7 @@ import pytest
 
 from regional_mom6 import hyperbolictan_thickness_profile
 from regional_mom6 import rectangular_hgrid
+from regional_mom6 import longitude_slicer
 
 from regional_mom6.utils import angle_between
 from regional_mom6.utils import latlon_to_cartesian
@@ -125,3 +126,24 @@ def test_quadrilateral_areas(lat, lon, true_area):
 )
 def test_rectangular_hgrid(lat, lon):
     assert isinstance(rectangular_hgrid(lat, lon), xr.Dataset)
+
+def test_longitude_slicer():
+    with pytest.raises(AssertionError):
+        nx, ny, nt = 10, 14, 5
+    
+        latitude_extent = (10, 20)
+        longitude_extent = (12, 18)
+
+        dims = ["lata", "lona", "time"]
+
+        data = xr.DataArray(
+            np.random.random((ny, nx, nt)),
+            dims=dims,
+            coords={
+                "lata": np.linspace(latitude_extent[0], latitude_extent[1], ny),
+                "lona": np.linspace(longitude_extent[0], longitude_extent[1], nx),
+                "time": np.linspace(0, 1000, nt),
+            },
+        )
+
+        longitude_slicer(data, longitude_extent, "lona")

--- a/tests/test_grid_generation.py
+++ b/tests/test_grid_generation.py
@@ -127,10 +127,11 @@ def test_quadrilateral_areas(lat, lon, true_area):
 def test_rectangular_hgrid(lat, lon):
     assert isinstance(rectangular_hgrid(lat, lon), xr.Dataset)
 
+
 def test_longitude_slicer():
     with pytest.raises(AssertionError):
         nx, ny, nt = 10, 14, 5
-    
+
         latitude_extent = (10, 20)
         longitude_extent = (12, 18)
 


### PR DESCRIPTION
Bug: The `assert`ion statement was calling `λ` that was never defined.

Now it's fixed + a simple test was added to ensure that the assertion is raised when appropriate.

Closes #129 