### PR TITLE
add explicity bathymetry.nc to MOM_input

### DIFF
--- a/demos/premade_run_directories/common_files/MOM_input
+++ b/demos/premade_run_directories/common_files/MOM_input
@@ -72,6 +72,7 @@ TOPO_CONFIG = "file"            !
                                 !     Phillips - ACC-like idealized topography used in the Phillips config.
                                 !     dense - Denmark Strait-like dense water formation and overflow.
                                 !     USER - call a user modified routine.
+TOPO_FILE = "bathymetry.nc"     ! Name of the file containing bathymetry information. 
 MINIMUM_DEPTH = 4.5             !   [m] default = 0.0
                                 ! If MASKING_DEPTH is unspecified, then anything shallower than MINIMUM_DEPTH is
                                 ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is


### PR DESCRIPTION
The default filename for topography is topog.nc. Need to overwrite it to bathymetry.nc in our naming conventions. 

closes #172 