### PR TITLE
(v0.6.0) Simplify boundary condition construction

### DIFF
--- a/demos/reanalysis-forced.ipynb
+++ b/demos/reanalysis-forced.ipynb
@@ -288,17 +288,7 @@
     "    glorys_path / \"ic_unprocessed.nc\", # directory where the unprocessed initial condition is stored, as defined earlier\n",
     "    ocean_varnames,\n",
     "    arakawa_grid=\"A\"\n",
-    "    )\n",
-    "\n",
-    "# Now iterate through our four boundaries \n",
-    "for i, orientation in enumerate([\"south\", \"north\", \"west\", \"east\"]):\n",
-    "    expt.rectangular_boundary(\n",
-    "        glorys_path / (orientation + \"_unprocessed.nc\"),\n",
-    "        ocean_varnames,\n",
-    "        orientation,    # Needs to know the cardinal direction of the boundary\n",
-    "        i + 1,          # Just a number to identify the boundary. Indexes from 1 \n",
-    "        arakawa_grid=\"A\"\n",
-    "        )"
+    "    )    "
    ]
   },
   {

--- a/demos/reanalysis-forced.ipynb
+++ b/demos/reanalysis-forced.ipynb
@@ -288,7 +288,15 @@
     "    glorys_path / \"ic_unprocessed.nc\", # directory where the unprocessed initial condition is stored, as defined earlier\n",
     "    ocean_varnames,\n",
     "    arakawa_grid=\"A\"\n",
-    "    )    "
+    "    )    \n",
+    "\n",
+    "# Set up the four boundary conditions. Remember that in the glorys_path, we have four boundary files names north_unprocessed.nc etc. \n",
+    "expt.rectangular_boundaries(\n",
+    "        glorys_path,\n",
+    "        ocean_varnames,\n",
+    "        boundaries = [\"south\", \"north\", \"west\", \"east\"],\n",
+    "        arakawa_grid = \"A\"\n",
+    "        )"
    ]
   },
   {

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -890,7 +890,6 @@ class experiment:
             },
         )
 
-
         self.ic_eta = eta_out
         self.ic_tracers = tracers_out
         self.ic_vels = vel_out

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -567,7 +567,12 @@ class experiment:
         return vcoord
 
     def initial_condition(
-        self, ic_path, varnames, arakawa_grid="A", vcoord_type="height"
+        self,
+        ic_path,
+        varnames,
+        arakawa_grid="A",
+        vcoord_type="height",
+        boundaries=["south", "north", "west", "east"],
     ):
         """
         Reads the initial condition from files in ``ic_path``, interpolates to the
@@ -874,11 +879,23 @@ class experiment:
                 "eta_t": {"_FillValue": None},
             },
         )
-        print("done setting up initial condition.")
 
         self.ic_eta = eta_out
         self.ic_tracers = tracers_out
         self.ic_vels = vel_out
+
+        # Now iterate through our four boundaries
+        for i, orientation in enumerate(boundaries, start=1):
+            self.rectangular_boundary(
+                glorys_path / (orientation + "_unprocessed.nc"),
+                ocean_varnames,
+                orientation,  # The cardinal direction of the boundary
+                i,  # A number to identify the boundary; indexes from 1
+                arakawa_grid=arakawa_grid,
+            )
+
+        print("done setting up initial condition.")
+
         return
 
     def rectangular_boundary(

--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -925,6 +925,15 @@ class experiment:
                     f"Invalid boundary direction: {i}. Must be one of ['south', 'north', 'west', 'east']"
                 )
 
+        if len(boundaries) < 4:
+            print(
+                "NOTE: the 'setup_run_directories' method assumes that you have four boundaries. You'll need to modify the MOM_input file manually to reflect the number of boundaries you have, and their orientations. You should be able to find the relevant section in the MOM_input file by searching for 'segment_'. Ensure that the segment names match those in your inputdir/forcing folder"
+            )
+
+        if len(boundaries) > 4:
+            raise ValueError(
+                "This method only supports up to four boundaries. To set up more complex boundary shapes you can manually call the 'simple_boundary' method for each boundary."
+            )
         # Now iterate through our four boundaries
         for i, orientation in enumerate(boundaries, start=1):
             self.simple_boundary(

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -443,7 +443,7 @@ def test_rectangular_boundaries(
             ),
         }
     )
-    eastern_boundary.to_netcdf(tmp_path / "east_unprocessed")
+    eastern_boundary.to_netcdf(tmp_path / "east_unprocessed.nc")
     eastern_boundary.close()
 
     expt = experiment(

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -471,4 +471,4 @@ def test_rectangular_boundaries(
         "tracers": {"temp": "temp", "salt": "salt"},
     }
 
-    expt.rectangular_boundaries(tmp_path, varnames)
+    expt.rectangular_boundaries(tmp_path, varnames,["east"])

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -471,4 +471,4 @@ def test_rectangular_boundaries(
         "tracers": {"temp": "temp", "salt": "salt"},
     }
 
-    expt.rectangular_boundaries(tmp_path, varnames,["east"])
+    expt.rectangular_boundaries(tmp_path, varnames, ["east"])

--- a/tests/test_expt_class.py
+++ b/tests/test_expt_class.py
@@ -355,7 +355,7 @@ def test_ocean_forcing(
         ),
     ],
 )
-def test_rectangular_boundary(
+def test_rectangular_boundaries(
     longitude_extent,
     latitude_extent,
     date_range,
@@ -471,4 +471,4 @@ def test_rectangular_boundary(
         "tracers": {"temp": "temp", "salt": "salt"},
     }
 
-    expt.rectangular_boundary(tmp_path / "east_unprocessed", varnames, "east", 1)
+    expt.rectangular_boundaries(tmp_path, varnames)


### PR DESCRIPTION
*Description edited by Ashley to reflect discussion below*
This PR aims to simplify the boundary condition construction in the simple case of four boundaries that are parallel to lines of constant longitude and latitude, as per the discussion in https://github.com/COSIMA/regional-mom6/issues/174.

To do this, we add a wrapper function that just calls the `simple_boundary` method for each cardinal direction requested. 

This PR includes a breaking API change since `rectangular_boundary` is renamed to `rectangular_boundaries` and also some of its args changed.

Closes https://github.com/COSIMA/regional-mom6/issues/174