### PR TITLE
Pin numpy<2.0.0

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,7 +23,7 @@ jobs:
         shell: bash -el {0}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,7 +23,7 @@ jobs:
         shell: bash -el {0}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/environment-ci.yml
+++ b/environment-ci.yml
@@ -3,3 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - esmpy
+  - numpy<2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "dask[array]",
   "dask[distributed]",
   "netCDF4",
-  "numpy >= 1.17.0",
+  "numpy >= 1.17.0, < 2.0.0",
   "scipy >= 1.2.0",
   "xarray",
   "xesmf >= 0.8.4",


### PR DESCRIPTION
~~I guess it's nice that we have type information encoded here now too. This does introduce a bit of an incompatibility *in the testing environment*, where numpy 2.0.0 is required, but it's not an issue for actual running.~~

Famous last words: it *is* an issue for running, at the moment. We will probably just have to restrict ourselves to numpy < 2.0.0 for the moment.