### PR TITLE
Freeze xarray version given update causes crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "netCDF4",
   "numpy >= 1.17.0, < 2.0.0",
   "scipy >= 1.2.0",
-  "xarray == 2024.7.0",
+  "xarray <= 2024.7.0",
   "xesmf >= 0.8.4",
   "f90nml >= 1.4.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "netCDF4",
   "numpy >= 1.17.0, < 2.0.0",
   "scipy >= 1.2.0",
-  "xarray",
+  "xarray == 2024.7.0",
   "xesmf >= 0.8.4",
   "f90nml >= 1.4.1",
 ]


### PR DESCRIPTION
New (24-9-0) xarray update causes error when calling bathymetry. A "strict" flag is added to one of the dask function calls which causes a crash. Need to freeze the version of xarray to fix for now, until we patch ahead of updating to new xarray version.

Bug found by @manishvenu