### PR TITLE
Rework OBC Mask

### DIFF
--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -2934,10 +2934,8 @@ class segment:
         }
         segment_out = rgd.mask_dataset(
             segment_out,
-            self.hgrid,
             self.bathymetry,
             self.orientation,
-            self.segment_name,
         )
         encoding_dict = rgd.generate_encoding(
             segment_out,
@@ -3192,9 +3190,7 @@ class segment:
             {"lon": f"lon_{self.segment_name}", "lat": f"lat_{self.segment_name}"}
         )
 
-        ds = rgd.mask_dataset(
-            ds, self.hgrid, self.bathymetry, self.orientation, self.segment_name
-        )
+        ds = rgd.mask_dataset(ds, self.bathymetry, self.orientation)
         ## Perform Encoding ##
 
         fname = f"{filename}_{self.segment_name}.nc"

--- a/regional_mom6/regridding.py
+++ b/regional_mom6/regridding.py
@@ -478,7 +478,7 @@ def get_boundary_mask(
     segment_name: str,
     minimum_depth=0,
     x_dim_name="lonh",
-    y_dim_name="lath"
+    y_dim_name="lath",
 ) -> np.ndarray:
     """
     Mask out the boundary conditions based on the bathymetry. We don't want to have boundary conditions on land.
@@ -578,7 +578,7 @@ def mask_dataset(
     segment_name: str,
     y_dim_name="lath",
     x_dim_name="lonh",
-    fill_value=-1e20
+    fill_value=-1e20,
 ) -> xr.Dataset:
     """
     This function masks the dataset to the provided bathymetry. If bathymetry is not provided, it fills all NaNs with 0.

--- a/regional_mom6/regridding.py
+++ b/regional_mom6/regridding.py
@@ -478,7 +478,7 @@ def get_boundary_mask(
     segment_name: str,
     minimum_depth=0,
     x_dim_name="lonh",
-    y_dim_name="lath",
+    y_dim_name="lath"
 ) -> np.ndarray:
     """
     Mask out the boundary conditions based on the bathymetry. We don't want to have boundary conditions on land.
@@ -560,11 +560,11 @@ def get_boundary_mask(
             boundary_mask[(i * 2)] = land
 
     # Add Exceptions. The Mask (Wet vs Not Wet) does not include the neighboring q point as ocean. That point is used at the boundary.
-
+    boundary_mask_og = boundary_mask.copy()
     for index in range(1, len(boundary_mask) - 1):
-        if boundary_mask[index - 1] == land and boundary_mask[index] == ocean:
+        if boundary_mask_og[index - 1] == land and boundary_mask_og[index] == ocean:
             boundary_mask[index - 1] = ocean
-        elif boundary_mask[index + 1] == land and boundary_mask[index] == ocean:
+        elif boundary_mask_og[index + 1] == land and boundary_mask_og[index] == ocean:
             boundary_mask[index + 1] = ocean
 
     return boundary_mask
@@ -578,6 +578,7 @@ def mask_dataset(
     segment_name: str,
     y_dim_name="lath",
     x_dim_name="lonh",
+    fill_value=-1e20
 ) -> xr.Dataset:
     """
     This function masks the dataset to the provided bathymetry. If bathymetry is not provided, it fills all NaNs with 0.
@@ -648,7 +649,7 @@ def mask_dataset(
             ds[var] = ds[var] * mask
 
             # Replace the land NaNs with a large FillValue
-            ds[var] = ds[var].fillna(-1.0e20)
+            ds[var] = ds[var].fillna(fill_value)
     else:
         regridding_logger.warning(
             "All NaNs filled b/c bathymetry wasn't provided to the function. Add bathymetry_path to the segment class to avoid this"

--- a/regional_mom6/utils.py
+++ b/regional_mom6/utils.py
@@ -407,3 +407,28 @@ def find_files_by_pattern(paths: list, patterns: list, error_message=None) -> li
         else:
             raise ValueError(error_message)
     return all_files
+
+
+def get_edge(ds, edge, x_name=None, y_name=None):
+    edge = edge.lower()
+    if edge not in {"north", "south", "east", "west"}:
+        raise ValueError("edge must be one of: 'north', 'south', 'east', 'west'")
+
+    # Infer x and y coordinate names if not given
+    if x_name is None or y_name is None:
+        for dim in ds.dims:
+            if x_name is None and dim.lower() in ("x", "lon", "longitude", "nxp"):
+                x_name = dim
+            if y_name is None and dim.lower() in ("y", "lat", "latitude", "nyp"):
+                y_name = dim
+    if x_name is None or y_name is None:
+        raise ValueError("Could not infer x/y coordinate names. Pass x_name/y_name.")
+
+    if edge == "north":
+        return ds.isel({y_name: -1})
+    if edge == "south":
+        return ds.isel({y_name: 0})
+    if edge == "east":
+        return ds.isel({x_name: -1})
+    if edge == "west":
+        return ds.isel({x_name: 0})

--- a/tests/test_regridding.py
+++ b/tests/test_regridding.py
@@ -140,34 +140,26 @@ def test_get_boundary_mask(get_curvilinear_hgrid):
     bathy = hgrid.isel(nyp=t_points.t_points_y, nxp=t_points.t_points_x)
     bathy["depth"] = (("t_points_y", "t_points_x"), (np.full(bathy.x.shape, 0)))
     north_mask = rgd.get_boundary_mask(
-        hgrid,
         bathy,
         "north",
-        "segment_002",
         y_dim_name="t_points_y",
         x_dim_name="t_points_x",
     )
     south_mask = rgd.get_boundary_mask(
-        hgrid,
         bathy,
         "south",
-        "segment_001",
         y_dim_name="t_points_y",
         x_dim_name="t_points_x",
     )
     east_mask = rgd.get_boundary_mask(
-        hgrid,
         bathy,
         "east",
-        "segment_003",
         y_dim_name="t_points_y",
         x_dim_name="t_points_x",
     )
     west_mask = rgd.get_boundary_mask(
-        hgrid,
         bathy,
         "west",
-        "segment_004",
         y_dim_name="t_points_y",
         x_dim_name="t_points_x",
     )
@@ -186,10 +178,8 @@ def test_get_boundary_mask(get_curvilinear_hgrid):
     for i in range(start_ind, end_ind + 1):
         bathy["depth"][-1][i] = 15
     north_mask = rgd.get_boundary_mask(
-        hgrid,
         bathy,
         "north",
-        "segment_002",
         y_dim_name="t_points_y",
         x_dim_name="t_points_x",
     )
@@ -207,10 +197,8 @@ def test_get_boundary_mask(get_curvilinear_hgrid):
     for i in range(start_ind, end_ind + 1):
         bathy["depth"][:, 0][i] = 15
     west_mask = rgd.get_boundary_mask(
-        hgrid,
         bathy,
         "west",
-        "segment_004",
         y_dim_name="t_points_y",
         x_dim_name="t_points_x",
     )
@@ -242,10 +230,8 @@ def test_mask_dataset(get_curvilinear_hgrid):
     fill_value = 36
     ds = rgd.mask_dataset(
         ds,
-        hgrid,
         bathy,
         "north",
-        "segment_002",
         y_dim_name="t_points_y",
         x_dim_name="t_points_x",
         fill_value=fill_value,

--- a/tests/test_regridding.py
+++ b/tests/test_regridding.py
@@ -174,7 +174,7 @@ def test_get_boundary_mask(get_curvilinear_hgrid):
 
     # Check corner property of mask, and ensure each direction is following what we expect
     for mask in [north_mask, south_mask, east_mask, west_mask]:
-        assert (mask==0).all()  # Ensure all other points are land
+        assert (mask == 0).all()  # Ensure all other points are land
     assert north_mask.shape == (hgrid.x[-1].shape)  # Ensure mask is the right shape
     assert south_mask.shape == (hgrid.x[0].shape)  # Ensure mask is the right shape
     assert east_mask.shape == (hgrid.x[:, -1].shape)  # Ensure mask is the right shape
@@ -196,14 +196,10 @@ def test_get_boundary_mask(get_curvilinear_hgrid):
 
     # Ensure coasts are ocean with a 1 cell buffer, for the 1-point (remember mask is on the hgrid boundary - so (6 *2 +2) - 1 -> (9 *2 +2) + 1)
     assert (
-        north_mask[(((start_ind * 2) + 1)-1) : (((end_ind * 2) + 1) + 1+ 1)] == 1
-    ).all()  
-    assert (
-        north_mask[0: (((start_ind * 2) + 1) - 1) ] == 0
-    ).all()  # Left Side
-    assert (
-        north_mask[ (((end_ind * 2) + 1) + 1 + 1):] == 0
-    ).all()  # Right Side
+        north_mask[(((start_ind * 2) + 1) - 1) : (((end_ind * 2) + 1) + 1 + 1)] == 1
+    ).all()
+    assert (north_mask[0 : (((start_ind * 2) + 1) - 1)] == 0).all()  # Left Side
+    assert (north_mask[(((end_ind * 2) + 1) + 1 + 1) :] == 0).all()  # Right Side
 
     # On E/W
     start_ind = 6
@@ -220,14 +216,10 @@ def test_get_boundary_mask(get_curvilinear_hgrid):
     )
     # Ensure coasts are ocean with a 1 cell buffer, for the 1-point (remember mask is on the hgrid boundary - so (6 *2 +2) - 1 -> (9 *2 +2) + 1)
     assert (
-        west_mask[(((start_ind * 2) + 1)-1) : (((end_ind * 2) + 1) + 1+ 1)] == 1
-    ).all()  
-    assert (
-        west_mask[0: (((start_ind * 2) + 1) - 1) ] == 0
-    ).all()  # Left Side
-    assert (
-        west_mask[ (((end_ind * 2) + 1) + 1 + 1):] == 0
-    ).all()  # Right Side
+        west_mask[(((start_ind * 2) + 1) - 1) : (((end_ind * 2) + 1) + 1 + 1)] == 1
+    ).all()
+    assert (west_mask[0 : (((start_ind * 2) + 1) - 1)] == 0).all()  # Left Side
+    assert (west_mask[(((end_ind * 2) + 1) + 1 + 1) :] == 0).all()  # Right Side
 
 
 def test_mask_dataset(get_curvilinear_hgrid):
@@ -244,10 +236,8 @@ def test_mask_dataset(get_curvilinear_hgrid):
     for i in range(start_ind, end_ind + 1):
         bathy["depth"][-1][i] = 15
 
-    ds["temp"][
-        start_ind * 2 + 2
-    ] = np.nan
-    
+    ds["temp"][start_ind * 2 + 2] = np.nan
+
     ds["temp"] = ds["temp"].expand_dims("nz_temp", axis=0)
     fill_value = 36
     ds = rgd.mask_dataset(
@@ -258,7 +248,7 @@ def test_mask_dataset(get_curvilinear_hgrid):
         "segment_002",
         y_dim_name="t_points_y",
         x_dim_name="t_points_x",
-        fill_value = fill_value
+        fill_value=fill_value,
     )
 
     assert (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from regional_mom6.utils import vecdot, angle_between
+from regional_mom6.utils import vecdot, angle_between, get_edge
 
 V1 = np.zeros((2, 4, 3))
 V2 = np.zeros((2, 4, 3))
@@ -39,3 +39,15 @@ def test_vecdot(v1, v2, true_v1dotv2):
 )
 def test_angle_between(v1, v2, v3, true_angle):
     assert np.isclose(angle_between(v1, v2, v3), true_angle)
+
+
+def test_get_edge(get_rectilinear_hgrid):
+    hgrid = get_rectilinear_hgrid
+    res = get_edge(hgrid, "north")
+    assert (res.x == hgrid.x.isel(nyp=-1)).all()
+    res = get_edge(hgrid, "south")
+    assert (res.x == hgrid.x.isel(nyp=0)).all()
+    res = get_edge(hgrid, "east")
+    assert (res.x == hgrid.x.isel(nxp=-1)).all()
+    res = get_edge(hgrid, "west")
+    assert (res.x == hgrid.x.isel(nxp=0)).all()


### PR DESCRIPTION
Details:
I've been taking a look at the OBC mask for our BGC stuff, and think I've come to an improvement/happy solution-> But it definetely needs to be tested on other people's computers!

Right now, our two big OBC generating functions, regrid_velocity_tracers & `regrid_tides`, pass their datasets through a `mask_dataset` function in `regridding.py`. If bathymetry is provided (and it is not by default), the dataset is masked, if bathy isn't provided, all NaNs are filled with zeros to avoid the failures we were getting in https://github.com/CROCODILE-CESM/regional-mom6/issues/25.

However, the problem(s) are:

1. The mask with bathymetry isn't great, for some reason we needed three additional real values at the coast on land & a real value at the corner -  weird land excpetions. 
2. The more important problem (since the previous problem can just be filled) is that it wasn't clear exactly at what point is the land-ocean cutoff. This is because boundaries are on q-u-v points versus tracer points, which is where depth is given.

The fix is that:

1. It seems like xarray/numpy NaNs just aren't working well in the OBCs, so instead if we fill with a fill value we get a much cleaner mask without those weird land_exceptions.  
2. Through some testing, the land-ocean cutoff is the single q-point beyond the MOM6 mask (MOM6 mask can be found in ocean static as "wet"), which makes a certain amount of sense. I can explain this if need be!

Changes:
1. Update `mask_dataset` and `get_boundary_mask` in `regridding.py` according to the description above.
2. Add a utils function for getting the edge of a dataset to make it cleaner.

