### PR TITLE
Simplify the create_regridder function 

### DIFF
--- a/regional_mom6/regridding.py
+++ b/regional_mom6/regridding.py
@@ -28,7 +28,7 @@ import dask.array as da
 import numpy as np
 import netCDF4
 from regional_mom6.utils import setup_logger, get_edge
-
+from os.path import isfile
 
 regridding_logger = setup_logger(__name__, set_handler=False)
 
@@ -209,7 +209,7 @@ def get_hgrid_arakawa_c_points(hgrid: xr.Dataset, point_type="t") -> xr.Dataset:
 def create_regridder(
     forcing_variables: xr.Dataset,
     output_grid: xr.Dataset,
-    outfile: Path = None,
+    outfile: Path = Path(""),
     method: str = "bilinear",
     locstream_out: bool = True,
     periodic: bool = False,
@@ -240,15 +240,6 @@ def create_regridder(
     """
     regridding_logger.info("Creating Regridder")
 
-    # If outfile exists, reuse weights generated from outfile
-    if outfile is not None and Path(outfile).exists():
-        regridding_logger.warning(
-            f"Using existing weights file at {outfile} to save computing time. Delete weights file to regenerate weights."
-        )
-        reuse_weights = True
-    else:
-        reuse_weights = False
-
     regridder = xe.Regridder(
         forcing_variables,
         output_grid,
@@ -256,7 +247,7 @@ def create_regridder(
         locstream_out=locstream_out,
         periodic=periodic,
         filename=outfile,
-        reuse_weights=reuse_weights,
+        reuse_weights=isfile(outfile),
     )
 
     return regridder

--- a/regional_mom6/regridding.py
+++ b/regional_mom6/regridding.py
@@ -253,7 +253,7 @@ def create_regridder(
         periodic=periodic,
         filename=outfile,
         reuse_weights=weights_exist,
-        unmapped_to_nan = True
+        unmapped_to_nan=True,
     )
 
     return regridder

--- a/regional_mom6/regridding.py
+++ b/regional_mom6/regridding.py
@@ -240,6 +240,11 @@ def create_regridder(
     """
     regridding_logger.info("Creating Regridder")
 
+    weights_exist = bool(outfile) and isfile(outfile)
+    if weights_exist:
+        regridding_logger.warning(
+            f"Using existing weights file at {outfile} to save computing time. Delete weights file to regenerate weights."
+        )
     regridder = xe.Regridder(
         forcing_variables,
         output_grid,
@@ -247,7 +252,8 @@ def create_regridder(
         locstream_out=locstream_out,
         periodic=periodic,
         filename=outfile,
-        reuse_weights=bool(outfile) and isfile(outfile),
+        reuse_weights=weights_exist,
+        unmapped_to_nan = True
     )
 
     return regridder

--- a/regional_mom6/regridding.py
+++ b/regional_mom6/regridding.py
@@ -209,7 +209,7 @@ def get_hgrid_arakawa_c_points(hgrid: xr.Dataset, point_type="t") -> xr.Dataset:
 def create_regridder(
     forcing_variables: xr.Dataset,
     output_grid: xr.Dataset,
-    outfile: Path = Path(""),
+    outfile: Path = None,
     method: str = "bilinear",
     locstream_out: bool = True,
     periodic: bool = False,
@@ -247,7 +247,7 @@ def create_regridder(
         locstream_out=locstream_out,
         periodic=periodic,
         filename=outfile,
-        reuse_weights=isfile(outfile),
+        reuse_weights=bool(outfile) and isfile(outfile),
     )
 
     return regridder


### PR DESCRIPTION
The `create_regridder` function default looks for the reuse_weights file if it exists using an if statement, instead we can follow this: https://github.com/pangeo-data/xESMF/pull/234#issuecomment-1409401017, which uses os.path.isfile instead.

Fixes https://github.com/CROCODILE-CESM/regional-mom6/issues/58