### PR TITLE
Fixes issue in setting up initial condition if the first layer of the vgrid is higher than the input data (glorys in the initial issue)

### DIFF
--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -1294,8 +1294,8 @@ class experiment:
             tracers_out["zl"] = tracers_out["zl"].diff("zl")
             dz = rgd.generate_dz(tracers_out, self.z)
 
-        tracers_out = tracers_out.interp({"zl": self.vgrid.zl.values})
-        vel_out = vel_out.interp({"zl": self.vgrid.zl.values})
+        tracers_out = tracers_out.interp({"zl": self.vgrid.zl.values}, kwargs={"fill_value": "extrapolate"}) # The extrapolate arg allows the initial condition to fill beyond the range of the input data.
+        vel_out = vel_out.interp({"zl": self.vgrid.zl.values}, kwargs={"fill_value": "extrapolate"})
 
         print("Saving outputs... ", end="")
 


### PR DESCRIPTION
See title! This fixes the issue of the vgrid being too high on the first level by just extrapolating from the 
lower levels in the input data
Helps with https://github.com/COSIMA/regional-mom6/issues/228