### PR TITLE
Add an opt-in ignore_degenerate option to regridder construction

### DIFF
--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -2285,6 +2285,7 @@ class segment:
         calendar="gregorian",
         fill_method=rgd.fill_missing_data,
         regridders=None,
+        ignore_degenerate=False,
     ):
         """
         Cut out and interpolate the velocities and tracers.
@@ -2304,6 +2305,11 @@ class segment:
                 multiple times for different time windows on the same grid (pass ``seg.regridders``
                 from a prior call). Default ``None`` — regridders are built and saved to
                 ``self.regridders``.
+            ignore_degenerate (bool): Passed through to regridder construction --
+                skip degenerate source cells instead of raising. Default ``False``.
+                Needed for source datasets with duplicate/collapsed cells near the
+                poles; see ``rgd.create_regridder``. Ignored when ``regridders`` is
+                supplied, since no regridder is built.
 
         """
         reprocessed_var_map = apply_arakawa_grid_mapping(
@@ -2333,6 +2339,7 @@ class segment:
                 Path(self.outfolder),
                 regridding_method,
                 self.orientation,
+                ignore_degenerate=ignore_degenerate,
             )
         self.regridders = regridders
 
@@ -2856,6 +2863,7 @@ def create_vt_regridders(
     outfolder: str,
     regridding_method: str,
     id: str = "",
+    ignore_degenerate: bool = False,
 ) -> dict[str, xe.Regridder]:
     """
     Create regridders for velocity and tracer variables based on the specified Arakawa grid.
@@ -2872,6 +2880,9 @@ def create_vt_regridders(
         outfolder: Path to the output folder where regridding weights are saved.
         regridding_method: The interpolation method (default: "bilinear").
         id: Optional string identifier appended to output weight filenames.
+        ignore_degenerate: Passed to ``rgd.create_regridder`` -- skip degenerate
+            source cells instead of raising (default: ``False``). See that
+            function for when this is needed.
 
     Returns:
         dict[str, xe.Regridder]: A dictionary containing the created regridders with keys:
@@ -2892,6 +2903,7 @@ def create_vt_regridders(
         coords,
         outfolder / f"weights/bilinear_tracer_weights_{id}.nc",
         method=regridding_method,
+        ignore_degenerate=ignore_degenerate,
     )
 
     if arakawa_grid == "B" or arakawa_grid == "C":
@@ -2905,6 +2917,7 @@ def create_vt_regridders(
             coords,
             outfolder / f"weights/bilinear_u_weights_{id}.nc",
             method=regridding_method,
+            ignore_degenerate=ignore_degenerate,
         )
     else:  # Arakawa A
         regridders["u"] = regridders["tracers"]
@@ -2920,6 +2933,7 @@ def create_vt_regridders(
             coords,
             outfolder / f"weights/bilinear_v_weights_{id}.nc",
             method=regridding_method,
+            ignore_degenerate=ignore_degenerate,
         )
     else:  # Arakawa A and B
         regridders["v"] = regridders["u"]

--- a/regional_mom6/regridding.py
+++ b/regional_mom6/regridding.py
@@ -215,6 +215,7 @@ def create_regridder(
     locstream_out: bool = True,
     periodic: bool = False,
     reuse_weights: bool = False,
+    ignore_degenerate: bool = False,
 ) -> xe.Regridder:
     """
     Basic regridder for any forcing variables. This is essentially a wrapper for
@@ -241,6 +242,15 @@ def create_regridder(
         weights from a previous grid do not silently produce wrong results.
         Set to ``True`` only when you are certain the grid has not changed,
         e.g. when reusing a :class:`segment` regridder across multiple time steps.
+    ignore_degenerate : bool, optional
+        Skip degenerate (duplicate or collapsed) source cells instead of raising,
+        i.e. ESMF's ``ignore_degenerate``; default: ``False``. Some global source
+        datasets have degenerate cells near the poles -- GLORYS, for instance, at
+        its southernmost latitudes -- and ESMF aborts the whole regrid with
+        ``ESMC_FieldRegridStore failed with rc=506 (Degenerate Element Detected)``
+        when it meets one. Set to ``True`` to drop those cells and continue.
+        Left ``False`` by default so a genuinely malformed source grid still fails
+        loudly rather than being silently regridded from a subset of its cells.
 
     Returns
     -------
@@ -262,6 +272,7 @@ def create_regridder(
         filename=outfile,
         reuse_weights=reuse_weights,
         unmapped_to_nan=True,
+        ignore_degenerate=ignore_degenerate,
     )
 
     return regridder


### PR DESCRIPTION
## Problem

`xe.Regridder()` aborts the entire regrid when ESMF meets a degenerate (duplicate or collapsed) source cell:

```
ESMC_FieldRegridStore failed with rc=506    (Degenerate Element Detected)
```

Some global source datasets have such cells near the poles — GLORYS, for instance, at its southernmost latitudes — so regridding OBC segments for a polar domain fails outright, even though only a handful of unusable source cells are involved. There's currently no way to get past it from `regional-mom6`'s API.

## Change

ESMF can skip those cells rather than fail (`ignore_degenerate`), so this exposes it as an **opt-in** parameter, threaded down the path that builds the segment regridders:

- `regridding.create_regridder(..., ignore_degenerate=False)` → passed to `xe.Regridder`
- `create_vt_regridders(..., ignore_degenerate=False)` → passed to all three `create_regridder` calls
- `segment.regrid_velocity_tracers(..., ignore_degenerate=False)` → passed to `create_vt_regridders`

Purely additive: 25 inserted lines, nothing deleted, no existing call site changed.


