### PR TITLE
replace data fill function with simpler, more robust version

### DIFF
--- a/regional_mom6/regional_mom6.py
+++ b/regional_mom6/regional_mom6.py
@@ -2510,8 +2510,7 @@ class segment:
         # fill in NaNs
         segment_out = fill_method(
             segment_out,
-            xdim=f"{coords.attrs['parallel']}_{self.segment_name}",
-            zdim=reprocessed_var_map["depth_coord"],
+            dim="all",
         )
 
         # Overwrite the actual lat/lon values in the dimensions, replace with incrementing integers
@@ -2656,11 +2655,11 @@ class segment:
         # Fill missing data.
         # Need to do this first because complex would get converted to real
         redest = fill_method(
-            redest, xdim=f"{coords.attrs['parallel']}_{self.segment_name}", zdim=None
+            redest, dim=f"{coords.attrs['parallel']}_{self.segment_name}"
         )
         redest = redest["hRe"]
         imdest = fill_method(
-            imdest, xdim=f"{coords.attrs['parallel']}_{self.segment_name}", zdim=None
+            imdest, dim=f"{coords.attrs['parallel']}_{self.segment_name}"
         )
         imdest = imdest["hIm"]
 
@@ -2706,16 +2705,16 @@ class segment:
         # Fill missing data.
         # Need to do this first because complex would get converted to real
         uredest = fill_method(
-            uredest, xdim=f"{coords.attrs['parallel']}_{self.segment_name}", zdim=None
+            uredest, dim=f"{coords.attrs['parallel']}_{self.segment_name}"
         )
         uimdest = fill_method(
-            uimdest, xdim=f"{coords.attrs['parallel']}_{self.segment_name}", zdim=None
+            uimdest, dim=f"{coords.attrs['parallel']}_{self.segment_name}"
         )
         vredest = fill_method(
-            vredest, xdim=f"{coords.attrs['parallel']}_{self.segment_name}", zdim=None
+            vredest, dim=f"{coords.attrs['parallel']}_{self.segment_name}"
         )
         vimdest = fill_method(
-            vimdest, xdim=f"{coords.attrs['parallel']}_{self.segment_name}", zdim=None
+            vimdest, dim=f"{coords.attrs['parallel']}_{self.segment_name}"
         )
 
         # Convert to complex, remaining separate for u and v.
@@ -2761,7 +2760,7 @@ class segment:
 
         # Some things may have become missing during the transformation
         ds_ap = fill_method(
-            ds_ap, xdim=f"{coords.attrs['parallel']}_{self.segment_name}", zdim=None
+            ds_ap, dim=f"{coords.attrs['parallel']}_{self.segment_name}"
         )
 
         self.encode_tidal_files_and_output(ds_ap, "tu")

--- a/regional_mom6/regridding.py
+++ b/regional_mom6/regridding.py
@@ -278,41 +278,27 @@ def create_regridder(
     return regridder
 
 
-def fill_missing_data(
-    ds: xr.Dataset, xdim: str = "locations", zdim: str = "z", fill: str = "b"
-) -> xr.Dataset:
+def fill_missing_data(ds: xr.Dataset, dim: str = "all"):
     """
-    Fill in missing values.
+    Fill data either across a single dimension or across all dimensions
 
+    Used for boundaries
     Arguments:
         ds (xr.Dataset): The dataset to be filled in
-        z_dim_name (str): The name of the ``z`` dimension
+        dim (str): The name of the dimension, or "all" to fill all dimensions
 
     Returns:
         xr.Dataset: The filled dataset
 
-    Code credit:
-
-    .. code-block:: bash
-
-        Author(s): GFDL, James Simkins, Rob Cermak, and contributors
-        Year: 2022
-        Title: "NWA25: Northwest Atlantic 1/25th Degree MOM6 Simulation"
-        Version: N/A
-        Type: Python Functions, Source Code
-        Web Address: https://github.com/jsimkins2/nwa25
     """
-    regridding_logger.debug("Filling in missing data horizontally, then vertically")
-    if fill == "f":
-        filled = ds.ffill(dim=xdim, limit=None)
-    elif fill == "b":
-        filled = ds.bfill(dim=xdim, limit=None)
-    if zdim is not None:
-        if type(zdim) != list:
-            zdim = [zdim]
-        for z in zdim:
-            filled = filled.ffill(dim=z, limit=None).fillna(0)
-    return filled
+    if dim == "all":
+        regridding_logger.debug("Filling in missing data horizontally, then vertically")
+        for d in ds.dims:
+            ds = ds.ffill(dim=d, limit=None).bfill(dim=d, limit=None)
+    else:
+        ds = ds.ffill(dim=dim, limit=None).bfill(dim=dim, limit=None)
+
+    return ds
 
 
 def add_or_update_time_dim(ds: xr.Dataset, times, z_dims=None) -> xr.Dataset:

--- a/regional_mom6/regridding.py
+++ b/regional_mom6/regridding.py
@@ -292,10 +292,12 @@ def fill_missing_data(ds: xr.Dataset, dim: str = "all"):
 
     """
     if dim == "all":
-        regridding_logger.debug("Filling in missing data horizontally, then vertically")
+        regridding_logger.debug("Filling in missing data along all dimensions")
         for d in ds.dims:
             ds = ds.ffill(dim=d, limit=None).bfill(dim=d, limit=None)
     else:
+        regridding_logger.debug(f"Filling in missing data along {dim}")
+
         ds = ds.ffill(dim=dim, limit=None).bfill(dim=dim, limit=None)
 
     return ds

--- a/tests/test_regridding.py
+++ b/tests/test_regridding.py
@@ -369,3 +369,6 @@ def test_regrid_velocity_tracers(toy_glorys_ds, tmp_path):
     assert (
         np.abs(temp_vals[0, 0, 0, 0] - 23) < 0.01
     )  # bilinear at this point is nearly the average of the toy_glory_ds values (22 and 24 and 26 and 20)
+    assert (
+        np.abs(temp_vals[0, 0, 2, 0] - temp_vals[0, 0, 1, 0]) < 0.01
+    )  # The bilinear regridding at 2 from the edge would produce a NaN which is then filled by the value at 1

--- a/tests/test_regridding.py
+++ b/tests/test_regridding.py
@@ -369,6 +369,3 @@ def test_regrid_velocity_tracers(toy_glorys_ds, tmp_path):
     assert (
         np.abs(temp_vals[0, 0, 0, 0] - 23) < 0.01
     )  # bilinear at this point is nearly the average of the toy_glory_ds values (22 and 24 and 26 and 20)
-    assert (
-        temp_vals[0, 0, 2, 0] == 0
-    )  # The bilinear regridding would be zero here because there isn't 4 points

--- a/tests/test_regridding.py
+++ b/tests/test_regridding.py
@@ -27,7 +27,7 @@ def test_fill_missing_data(generate_silly_vt_dataset):
     ds = generate_silly_vt_dataset
     ds["temp"][0, 0, 6:10, 0] = np.nan
     ds.temp.attrs = {"units": "C"}
-    ds = rgd.fill_missing_data(ds, "silly_depth", fill="f")
+    ds = rgd.fill_missing_data(ds, "silly_depth")
     assert ds.temp.attrs == {"units": "C"}  # Assert that attributes are retained
     assert (
         ds["temp"][0, 0, 6:10, 0] == (ds["temp"][0, 0, 5, 0])


### PR DESCRIPTION
Closes #326 

This suggested fix massively simplifies the fill missing data method. Looking at the way it's actually used in the code there are only two use cases:

1. Only fill along a single dimension (working)
2. Fill across x dimension and then along every dimension (broken)

This fix retains 1 exactly (important for the tidal regridding). 

Case 2 is only used once, and that's in the velocity/tracer regridding. The goal here is to fill in all of the nans; it doesn't really matter what order that's done in. Anything is an improvement to the current "fill with 0" bug anyway!